### PR TITLE
ci: add missing pull-request labeler configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "**/*.md"


### PR DESCRIPTION
## Summary
- add the missing default .github/labeler.yml consumed by ctions/labeler@v4
- apply the existing documentation label to docs and Markdown changes

## Validation
- parsed the configuration as YAML locally

This is intentionally limited to the broken labeler configuration.